### PR TITLE
JUnit Platform: report IncompleteExecutionException as aborted

### DIFF
--- a/testBalloon-framework-core/src/jvmMain/kotlin/de/infix/testBalloon/framework/core/internal/integration/TestBalloonJUnitPlatformTestEngine.kt
+++ b/testBalloon-framework-core/src/jvmMain/kotlin/de/infix/testBalloon/framework/core/internal/integration/TestBalloonJUnitPlatformTestEngine.kt
@@ -302,9 +302,9 @@ private val TestElement.Event.Finished.executionResult: TestExecutionResult
     get() =
         when (throwable) {
             null -> TestExecutionResult.successful()
-            is org.opentest4j.IncompleteExecutionException,
-            is FailFastException,
-                -> TestExecutionResult.aborted(throwable)
+
+            is FailFastException, is org.opentest4j.IncompleteExecutionException ->
+                TestExecutionResult.aborted(throwable)
 
             else -> TestExecutionResult.failed(throwable)
         }

--- a/testBalloon-framework-core/src/jvmMain/kotlin/de/infix/testBalloon/framework/core/internal/integration/TestBalloonJUnitPlatformTestEngine.kt
+++ b/testBalloon-framework-core/src/jvmMain/kotlin/de/infix/testBalloon/framework/core/internal/integration/TestBalloonJUnitPlatformTestEngine.kt
@@ -302,7 +302,10 @@ private val TestElement.Event.Finished.executionResult: TestExecutionResult
     get() =
         when (throwable) {
             null -> TestExecutionResult.successful()
-            is FailFastException -> TestExecutionResult.aborted(throwable)
+            is org.opentest4j.IncompleteExecutionException,
+            is FailFastException,
+                -> TestExecutionResult.aborted(throwable)
+
             else -> TestExecutionResult.failed(throwable)
         }
 


### PR DESCRIPTION
This allows support for JUnit Platform Assumptions, or other mechanisms for aborting a test and marking it as 'skipped'.